### PR TITLE
Fix `server?` method

### DIFF
--- a/lib/que.rb
+++ b/lib/que.rb
@@ -80,7 +80,7 @@ module Que
     end
 
     def server?
-      defined?(Que::CommandLineInterface).nil?
+      !defined?(Que::CommandLineInterface).nil?
     end
 
     # Support simple integration with many common connection pools.


### PR DESCRIPTION
My understanding is that the `server?` method is supposed to return `true` if the current process is the queue server. It looks like the method is missing a `!`. Right now, it is returning `false` for the queue server and `true` for non-queue processes.
